### PR TITLE
DynamicRelationshipType overwrites the toString method

### DIFF
--- a/src/main/java/org/neo4j/rest/graphdb/traversal/RestTraversal.java
+++ b/src/main/java/org/neo4j/rest/graphdb/traversal/RestTraversal.java
@@ -146,7 +146,7 @@ public class RestTraversal implements RestTraversalDescription {
             description.put("relationships",new HashSet<Map<String,Object>>());
         }
         Set<Map<String,Object>> relationships= (Set<Map<String, Object>>) description.get("relationships");
-        relationships.add(toMap("type", relationshipType, "direction", directionString(direction)));
+        relationships.add(toMap("type", relationshipType.name(), "direction", directionString(direction)));
         return this;
     }
 


### PR DESCRIPTION
If I add some relationships to RestTraversalDescription I have the problem that the traverse returns 0 nodes. 

I figured out that DynamicRelationshipType overwrites toString to "DynamicRelationshipType[" + this.name() + "]". This is used to fill a map, that is used to fill the JSON for the POST call. But since toString does not return the type as String only, a wrong JSON is constructed.

The merge request fixes the error for me. But I am not sure if I am doing right...
