### PR TITLE
value data can be null

### DIFF
--- a/src/main/java/org/neo4j/rest/graphdb/entity/RestEntity.java
+++ b/src/main/java/org/neo4j/rest/graphdb/entity/RestEntity.java
@@ -56,10 +56,12 @@ public class RestEntity implements PropertyContainer, UpdatableRestResult<RestEn
     public RestEntity( Map<?, ?> data, RestAPI restApi ) {
         this.structuralData = data;
         this.restApi = restApi;
-        this.propertyData = (Map<String, Object>) data.get( "data" );
+        if(data != null) {
+            this.propertyData = (Map<String, Object>) data.get( "data" );
+            String uri = (String) data.get( "self" );
+            this.restRequest = restApi.getRestRequest().with( uri );
+        }
         this.lastTimeFetchedPropertyData = System.currentTimeMillis();
-        String uri = (String) data.get( "self" );
-        this.restRequest = restApi.getRestRequest().with( uri );
     }
 
     public String getUri() {       


### PR DESCRIPTION
I've implemented a test version of a RestOldTraverWrapper to support the old traverser for neo4j-scala (typed traverser for Neo4j Server). In my tests the value for data can be null, if I use the builtin return filter "all".
The data parameter is created in method parseFullPath of class RestPathParser. Seems that in the include-start-node-case not all fields ("start" or "end") are set.

Dont know if this is a valid patch, because I have a very special use case...
