### PR TITLE
support for request/response logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,4 @@ _timeouts in seconds_
 * org.neo4j.rest.driver="neo4j-rest-graphdb/1.8M07"
 * org.neo4j.rest.stream=true
 * org.neo4j.rest.batch_transactions=true (convert transaction scope into batch-rest-operations)
-
-
+* org.neo4j.rest.logging_filter=false (set to true if verbose request/response logging should be enabled)

--- a/src/main/java/org/neo4j/rest/graphdb/ExecutingRestRequest.java
+++ b/src/main/java/org/neo4j/rest/graphdb/ExecutingRestRequest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
 
+import com.sun.jersey.api.client.filter.LoggingFilter;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.rest.graphdb.util.Config;
 import org.neo4j.rest.graphdb.util.JsonHelper;
@@ -69,6 +70,9 @@ public class ExecutingRestRequest implements RestRequest {
         client.setReadTimeout(Config.getReadTimeout());
         client.setChunkedEncodingSize(8*1024);
         userAgent.install(client);
+        if (Config.useLoggingFilter()) {
+            client.addFilter(new LoggingFilter());
+        }
         return client;
     }
 

--- a/src/main/java/org/neo4j/rest/graphdb/util/Config.java
+++ b/src/main/java/org/neo4j/rest/graphdb/util/Config.java
@@ -25,6 +25,7 @@ public class Config {
     public final static String CONFIG_PREFIX = "org.neo4j.rest.";
     public static final String CONFIG_STREAM = CONFIG_PREFIX + "stream";
     public static final String CONFIG_BATCH_TRANSACTION = CONFIG_PREFIX+"batch_transaction";
+    public static final String CONFIG_LOG_REQUESTS = CONFIG_PREFIX+"logging_filter";
 
     public static int getConnectTimeout() {
         return getTimeout("connect_timeout", 30);
@@ -40,6 +41,10 @@ public class Config {
 
     public static boolean useBatchTransactions() {
         return System.getProperty(CONFIG_BATCH_TRANSACTION,"true").equalsIgnoreCase("true");
+    }
+
+    public static boolean useLoggingFilter() {
+        return System.getProperty(CONFIG_LOG_REQUESTS,"false").equalsIgnoreCase("true");
     }
 
     private static int getTimeout(final String param, final int defaultValue) {


### PR DESCRIPTION
If system property org.neo4j.rest.logging_filter is set to true, verbose request/response logging using Jersey's com.sun.jersey.api.client.filter.LoggingFilter is enabled.
