### PR TITLE
Changed stream type and size to to deal with larger requests

### DIFF
--- a/src/main/java/org/neo4j/rest/graphdb/ExecutingRestRequest.java
+++ b/src/main/java/org/neo4j/rest/graphdb/ExecutingRestRequest.java
@@ -139,15 +139,10 @@ public class ExecutingRestRequest implements RestRequest {
     }
 
     private InputStream toInputStream(Object data) {
-        try {
-            if (data instanceof InputStream) return (InputStream) data;
-            PipedInputStream inputStream = new PipedInputStream(8 * 1024);
-            PipedOutputStream outputStream = new PipedOutputStream(inputStream);
-            StreamJsonHelper.writeJsonTo(data, outputStream);
-            return inputStream;
-        } catch (IOException e) {
-            throw new RuntimeException("Error writing "+data+" to stream",e);
-        }
+        if (data instanceof InputStream) return (InputStream) data;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(1024 * 1024);
+        StreamJsonHelper.writeJsonTo(data, outputStream);
+        return new ByteArrayInputStream(outputStream.toByteArray());
     }
 
     @Override


### PR DESCRIPTION
The current library fails during json serialization if the size of  the objects being pushed
to the database is to large/to many.

We changed the stream from being a PipedInputStream to a byte array stream and increased
the size of the buffer to more fit our needs.

The size should be configurable (make it a constant is probably enough) but we didn't want to make
to large change.
