### PR TITLE
org.neo4j.rest.batch_transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ _timeouts in seconds_
 * org.neo4j.rest.connect_timeout=30
 * org.neo4j.rest.driver="neo4j-rest-graphdb/1.8.RC1"
 * org.neo4j.rest.stream=true
-* org.neo4j.rest.batch_transactions=false (convert transaction scope into batch-rest-operations)
+* org.neo4j.rest.batch_transaction=false (convert transaction scope into batch-rest-operations)
 * org.neo4j.rest.logging_filter=false (set to true if verbose request/response logging should be enabled)


### PR DESCRIPTION
Hi,

We noticed that the property that triggers batch operations was listed as '...batch_transactions' rather than '...batch_transaction' in the README.
