### PR TITLE
Please make a release 1.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-rest-graphdb</artifactId>
     <packaging>jar</packaging>
-    <version>1.8-SNAPSHOT</version>
+    <version>1.8.2</version>
     <name>Neo4j - Rest GraphDatabaseService Wrapper</name>
     <description>Neo4j REST binding implementing the GraphDatabaseService interface.</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.6.1</slf4j.version>
-        <neo4j.version>1.8.1</neo4j.version>
+        <neo4j.version>1.8.2</neo4j.version>
         <jersey.version>1.4</jersey.version>
         <blueprints.version>1.2</blueprints.version>
         <gremlin.version>1.5</gremlin.version>


### PR DESCRIPTION
Without java-rest-binding depending on neo4j 1.8.2, we get deps to 1.8.1 in our projects.
