### PR TITLE
Reducing Jackson dependencies to avoid conflicts with JAX-RS Providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ the relevant Commercial Agreement.
     <dependencies>
         <dependency>
           <groupId>org.codehaus.jackson</groupId>
-          <artifactId>jackson-jaxrs</artifactId>
+          <artifactId>jackson-mapper-asl</artifactId>
           <version>1.9.7</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
In my application, I have a custom JAX-RS Provider to serialize/deserialize Json with [Gson](https://code.google.com/p/google-gson/) library. When add the java-rest-bind dependency, the application server scans all possible providers and uses the Jackson JAX-RS provider instead of my provider.

Reducing the dependency to only jackson mappers, solve this problem and reduce project size.
