### PR TITLE
Improve test robustness.

### DIFF
--- a/src/test/java/org/neo4j/rest/graphdb/RestAPITest.java
+++ b/src/test/java/org/neo4j/rest/graphdb/RestAPITest.java
@@ -393,6 +393,7 @@ public class RestAPITest extends RestTestBase {
     public void testGetAllLabelNames() throws Exception {
         RestNode node = restAPI.createNode(map("name","foo bar"));
         node.addLabel(LABEL_FOO);
-        assertEquals(asList(LABEL_FOO.name(),LABEL_BAR.name()),restAPI.getAllLabelNames());
+        node.addLabel(LABEL_BAR);
+        assertThat(restAPI.getAllLabelNames(), hasItems(LABEL_FOO.name(),LABEL_BAR.name()));
     }
 }


### PR DESCRIPTION
Test failed on my machine since the DB knew a third label 'TestPerson',
created by org.neo4j.rest.graphdb.RestNodeTest#testGetNodeLabels.
The updated test ignores any existing labels beyond those that should be
created during the test. Also solves intermittent failures due to the
order of the labels returned being undefined and thus changing
occassionally.
